### PR TITLE
Full width callouts/notifications

### DIFF
--- a/source/component-budgets.html.erb
+++ b/source/component-budgets.html.erb
@@ -9,7 +9,7 @@ activesubpage: component-budgets
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/component-debates.html.erb
+++ b/source/component-debates.html.erb
@@ -9,7 +9,7 @@ activesubpage: component-debates
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/component-meetings.html.erb
+++ b/source/component-meetings.html.erb
@@ -9,7 +9,7 @@ activesubpage: component-meetings
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/component-proposals.html.erb
+++ b/source/component-proposals.html.erb
@@ -9,7 +9,7 @@ activesubpage: component-proposals
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/component-results.html.erb
+++ b/source/component-results.html.erb
@@ -9,7 +9,7 @@ activesubpage: component-results
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/home.html.erb
+++ b/source/home.html.erb
@@ -8,6 +8,7 @@ activesection: home
   <%= partial 'partials/home_nav' %>
 </div>
 <div class="layout-content">
+  <%= partial 'partials/callouts_full' %>
   <div class="container">
     <h1>Decidim Admin</h1>
     <p>

--- a/source/partials/_callouts_full.html.erb
+++ b/source/partials/_callouts_full.html.erb
@@ -1,0 +1,26 @@
+<div class="callout-wrapper">
+  <div class="callout alert callout--full" data-closable>
+    La has liado pardísima y todo se ha roto. Congrats.
+    <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="callout warning callout--full" data-closable>
+    No, en serio, ve con cuidado.
+    <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="callout success callout--full" data-closable>
+    Ahora lo estás haciendo bien, ¡campeón!
+    <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="callout callout--full" data-closable>
+    Mira, todo me da un poco igual.
+    <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+</div>

--- a/source/process-admin.html.erb
+++ b/source/process-admin.html.erb
@@ -8,7 +8,7 @@ activepage: process-admin
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-categories.html.erb
+++ b/source/process-categories.html.erb
@@ -9,7 +9,7 @@ activepage: process-categories
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-components.html.erb
+++ b/source/process-components.html.erb
@@ -8,7 +8,7 @@ activepage: process-components
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-docs.html.erb
+++ b/source/process-docs.html.erb
@@ -9,7 +9,7 @@ activepage: process-docs
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-info.html.erb
+++ b/source/process-info.html.erb
@@ -9,7 +9,7 @@ activepage: process-info
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-pages.html.erb
+++ b/source/process-pages.html.erb
@@ -8,7 +8,7 @@ activepage: process-pages
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/process-steps-new.html.erb
+++ b/source/process-steps-new.html.erb
@@ -9,7 +9,7 @@ activepage: process-steps
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <form class="form">

--- a/source/process-steps.html.erb
+++ b/source/process-steps.html.erb
@@ -9,7 +9,7 @@ activepage: process-steps
 <div class="layout-nav">
   <%= partial 'partials/process_sub_nav' %>
 </div>
-<div class="layout-content">
+<div class="layout-content has-process-title">
   <div class="container">
     <%= partial 'partials/process_title' %>
     <div class="card">

--- a/source/stylesheets/modules/_callouts.scss
+++ b/source/stylesheets/modules/_callouts.scss
@@ -1,0 +1,32 @@
+.callout.callout--full{
+  border: 0;
+  margin-bottom: 0;
+  background-color: $primary-color;
+  font-weight: 600;
+  color: $white;
+  &.warning{
+    background-color: $warning-color;
+  }
+  &.success{
+    background-color: $success-color;
+  }
+  &.alert{
+    background-color: $alert-color;
+  }
+
+  p:last-of-type{
+    margin-bottom: 0;
+  }
+
+  .close-button{
+    color: white;
+  }
+}
+
+
+.has-process-title .callout-wrapper{
+  @include breakpoint(large){
+    padding-top: $process-title-height;
+    margin-bottom: -$process-title-height;
+  }
+}

--- a/source/stylesheets/modules/_modules.scss
+++ b/source/stylesheets/modules/_modules.scss
@@ -16,6 +16,7 @@
 @import "process-header";
 
 //Contents
+@import "callouts";
 @import "cards";
 @import "table-list";
 @import "action-icon";

--- a/source/stylesheets/modules/_secondary-nav.scss
+++ b/source/stylesheets/modules/_secondary-nav.scss
@@ -44,7 +44,7 @@ $process-title-height: 3rem;
 .secondary-nav--subnav{
   padding-top: 2rem;
 
-  @include breakpoint(mediumlarge){
+  @include breakpoint(large){
     min-height: calc(100% - #{$process-title-height});
     margin-top: $process-title-height;
   }
@@ -75,13 +75,13 @@ $process-title-height: 3rem;
 
 
 .process-title{
-  @include breakpoint(mediumlarge){
+  @include breakpoint(large){
     margin-bottom: $process-title-height;
   }
 }
 
 .process-title-content{
-  @include breakpoint(mediumlarge){
+  @include breakpoint(large){
     position: absolute;
     left: 120px;
     right: 0;


### PR DESCRIPTION
#### :tophat: Scope of work
Full width callouts/notifications. Fixes in sub-nav in medium screen sizes (menu hidden).

#### :pushpin: Related Issues
- Fixes #7

### :camera: URLs
![full-width callouts](https://cloud.githubusercontent.com/assets/468685/23070336/1c9dd8e6-f52b-11e6-9d3d-88de636f394c.png)


#### :ghost: GIF (optional)
![](http://i.giphy.com/12d26S5UN4lY4w.gif)
