### PR TITLE
Datepicker/calendar for date inputs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "foundation-sites": "~6.3.0",
     "what-input": "~4.0.4",
-    "modernizr": "~2.8.3"
+    "modernizr": "~2.8.3",
+    "foundation-datepicker": "~1.5.6"
   }
 }

--- a/source/form-with-datepicker.html.erb
+++ b/source/form-with-datepicker.html.erb
@@ -22,7 +22,7 @@ activesection: processes
         </div>
         <div class="card-section">
           <p>
-            Lanzado con el atributo <code>data-datepicker</code>.
+            Lanzado con el atributo <code>data-datepicker</code> en un <code>&lt;input type="text"&gt;</code>.
           </p>
           <p>
             Fecha inicial con el atributo <code>data-startdate</code>

--- a/source/form-with-datepicker.html.erb
+++ b/source/form-with-datepicker.html.erb
@@ -1,0 +1,55 @@
+---
+title: Decidim Admin
+activesection: processes
+---
+
+<%= partial 'partials/template_top' %>
+<div class="layout-nav">
+  <%= partial 'partials/process_nav' %>
+</div>
+<div class="layout-content">
+  <div class="container">
+    <h2 class="process-title-summary">Ejemplo de form con validación</h2>
+    <p>
+      Formulario con ejemplos de validación en tabs (con errores custom),
+      validación sin tabs con errores custom, validación normal (Foundation
+       Abide) y campos sin validación.
+    </p>
+    <form class="form" data-abide novalidate>
+      <div class="card">
+        <div class="card-divider">
+          <h2 class="card-title">Elemento de fecha con Foundation Datepicker</h2>
+        </div>
+        <div class="card-section">
+          <p>
+            Lanzado con el atributo <code>data-datepicker</code>.
+          </p>
+          <p>
+            Fecha inicial con el atributo <code>data-startdate</code>
+             (dd-mm-yyyy), puede estar en blanco.
+          </p>
+          <p>
+            Idioma recogido con el atributo <code>lang</code> de la etiqueta
+             <code>&lt;html&gt;</code>.
+          </p>
+          <div class="row">
+            <div class="columns xlarge-6">
+              <label for="process-date">Fecha de inicio</label>
+              <input type="text" data-datepicker data-startdate="" required name="process-date" placeholder="dd/mm/aaaa" id="process-date">
+              <span class="form-error">
+                Por favor, selecciona una fecha de inicio.
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div data-abide-error class="alert callout" style="display: none;">
+        <p><i class="fi-alert"></i> Hay errores en el formulario, por favor, revísalo.</p>
+      </div>
+      <div class="button--double form-general-submit">
+        <button type="submit" class="button">Guardar</button>
+      </div>
+    </form>
+  </div>
+</div>
+<%= partial 'partials/template_bottom' %>

--- a/source/form-with-datepicker.html.erb
+++ b/source/form-with-datepicker.html.erb
@@ -9,12 +9,7 @@ activesection: processes
 </div>
 <div class="layout-content">
   <div class="container">
-    <h2 class="process-title-summary">Ejemplo de form con validación</h2>
-    <p>
-      Formulario con ejemplos de validación en tabs (con errores custom),
-      validación sin tabs con errores custom, validación normal (Foundation
-       Abide) y campos sin validación.
-    </p>
+    <h2 class="process-title-summary">Ejemplo de form con datepicker</h2>
     <form class="form" data-abide novalidate>
       <div class="card">
         <div class="card-divider">

--- a/source/form-with-validation.html.erb
+++ b/source/form-with-validation.html.erb
@@ -156,7 +156,7 @@ activesection: processes
           <div class="row">
             <div class="columns xlarge-6">
               <label for="process-date">Fecha de inicio</label>
-              <input type="date" required name="process-date" placeholder="dd/mm/aaaa" id="process-date">
+              <input type="text" data-datepicker data-startdate="21-02-2017" required name="process-date" placeholder="dd/mm/aaaa" id="process-date">
               <span class="form-error">
                 Por favor, selecciona una fecha de inicio.
               </span>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -103,6 +103,9 @@ title: Decidim Admin
             <li>
             <a href="/form-with-validation">Formulario con validaciones</a>
             </li>
+            <li>
+            <a href="/form-with-datepicker">Formulario con calendario/datepicker</a>
+            </li>
           </ul>
         </div>
       </div>

--- a/source/javascripts/body.js
+++ b/source/javascripts/body.js
@@ -2,8 +2,12 @@
 //= require what-input/dist/what-input.min
 
 //= require foundation_requires
+//= require foundation-datepicker/js/foundation-datepicker
+//= require foundation-datepicker/js/locales/foundation-datepicker.es.js
+//= require foundation-datepicker/js/locales/foundation-datepicker.ca.js
 //= require form_validation_multitab
 //= require form_validation_custom_errors
+//= require form_datepicker
 
 //= require svg4everybody.min.js
 
@@ -15,4 +19,5 @@ $(function(){
   svg4everybody();
   formValidationMultitab();
   formValidationCustomErrors();
+  formDatePicker();
 });

--- a/source/javascripts/form_datepicker.js
+++ b/source/javascripts/form_datepicker.js
@@ -1,0 +1,16 @@
+function formDatePicker(){
+  $('[data-datepicker]').each(
+    function(){
+      var customStartDate = $(this).attr('data-startdate') || '',
+      selectedLang = $("html").attr('lang') || '';
+      $(this).fdatepicker({
+    		initialDate: customStartDate,
+    		format: 'dd-mm-yyyy',
+        language: selectedLang,
+    		disableDblClickSelection: true,
+    		leftArrow:'<<',
+    		rightArrow:'>>'
+    	});
+    }
+  );
+}

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="es">
   <head>
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">

--- a/source/stylesheets/_decidim.scss
+++ b/source/stylesheets/_decidim.scss
@@ -5,4 +5,6 @@
 @import "foundation";
 @include foundation-everything();
 
+@import "plugins/foundation-datepicker";
+
 @import "modules/modules";

--- a/source/stylesheets/plugins/_foundation-datepicker.scss
+++ b/source/stylesheets/plugins/_foundation-datepicker.scss
@@ -1,0 +1,223 @@
+$calendar-bg-color: $white;
+$calendar-border: 1px solid rgba(0, 0, 0, 0.1);
+$calendar-border-color: rgba(0, 0, 0, 0.1);
+$calendar-active-color: $primary-color;
+$calendar-bg-hover: $lighter-gray;
+$calendar-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+$calendar-color-old: $medium-gray;
+$calendar-color-disabled: $light-gray;
+$calendar-radius: $global-radius;
+
+.datepicker {
+  display: none;
+  position: absolute;
+  padding: 4px;
+  margin-top: 1px;
+  direction: ltr;
+}
+
+.datepicker.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  float: left;
+  display: none;
+  min-width: 160px;
+  list-style: none;
+  background-color: $calendar-bg-color;
+  border: $calendar-border;
+  border-radius: $calendar-radius;
+  box-shadow: $calendar-shadow;
+  background-clip: padding-box;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.datepicker.dropdown-menu th {
+  padding: 4px 5px;
+}
+
+.datepicker.dropdown-menu td {
+  padding: 4px 5px;
+}
+
+.datepicker table {
+  border: 0;
+  margin: 0;
+  width: auto;
+}
+
+.datepicker table tr td span {
+  display: block;
+  width: 23%;
+  height: 54px;
+  line-height: 54px;
+  float: left;
+  margin: 1%;
+  cursor: pointer;
+}
+
+.datepicker td {
+  text-align: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  font-size: 12px;
+  padding: 4px 8px;
+  background: $calendar-bg-color;
+  cursor: pointer;
+}
+
+.datepicker td.active.day,
+.datepicker td.active.year {
+  background: $calendar-active-color;
+}
+
+.datepicker .day:hover,
+.datepicker .date-switch:hover,
+.datepicker .prev:hover,
+.datepicker .next:hover,
+.datepicker .month:hover,
+.datepicker .year:hover{
+  background-color: $calendar-bg-hover;
+  &.active{
+    background: $calendar-active-color;
+  }
+}
+
+
+.datepicker td.new,
+.datepicker td.old {
+  color: $calendar-color-old;
+}
+
+.datepicker td span.active {
+  background: $calendar-active-color;
+}
+
+.datepicker td.day.disabled {
+  color: $calendar-color-disabled;
+}
+
+.datepicker td span.month.disabled,
+.datepicker td span.year.disabled {
+  color: $calendar-color-disabled;
+}
+
+.datepicker th {
+  text-align: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  font-size: 12px;
+  padding: 4px 8px;
+  background: $calendar-bg-color;
+  cursor: pointer;
+}
+
+.datepicker th.active.day,
+.datepicker th.active.year {
+  background: $calendar-active-color;
+}
+
+.datepicker th.date-switch {
+  width: 145px;
+}
+
+.datepicker th span.active {
+  background: $calendar-active-color;
+}
+
+.datepicker .cw {
+  font-size: 10px;
+  width: 12px;
+  padding: 0 2px 0 5px;
+  vertical-align: middle;
+}
+
+.datepicker.days div.datepicker-days {
+  display: block;
+}
+
+.datepicker.months div.datepicker-months {
+  display: block;
+}
+
+.datepicker.years div.datepicker-years {
+  display: block;
+}
+
+.datepicker thead tr:first-child th {
+  cursor: pointer;
+}
+
+.datepicker thead tr:first-child th.cw {
+  cursor: default;
+  background-color: transparent;
+}
+
+.datepicker tfoot tr:first-child th {
+  cursor: pointer;
+}
+
+.datepicker-inline {
+  width: 220px;
+}
+
+.datepicker-rtl {
+  direction: rtl;
+}
+
+.datepicker-rtl table tr td span {
+  float: right;
+}
+
+.datepicker-dropdown {
+  top: 0;
+  left: 0;
+}
+
+.datepicker-dropdown:before {
+  content: '';
+  display: inline-block;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-bottom-color: $calendar-border-color;
+  position: absolute;
+  top: -7px;
+  left: 6px;
+}
+
+.datepicker-dropdown:after {
+  content: '';
+  display: inline-block;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid $calendar-bg-color;
+  position: absolute;
+  top: -6px;
+  left: 7px;
+}
+
+.datepicker > div,
+.datepicker-dropdown::after,
+.datepicker-dropdown::before {
+  display: none;
+}
+
+.datepicker-close {
+  position: absolute;
+  top: -30px;
+  right: 0;
+  width: 15px;
+  height: 30px;
+  padding: 0;
+  display: none;
+}
+
+.table-striped .datepicker table tr td,
+.table-striped .datepicker table tr th {
+  background-color: transparent;
+}


### PR DESCRIPTION
#### :tophat: Scope of work
Foundation datepicker, behaviour and styles for date inputs. Use `<input type="text">` instead.

#### :pushpin: Related Issues
- Fixes #8

![captura de pantalla 2017-02-21 a las 12 17 09](https://cloud.githubusercontent.com/assets/468685/23162721/b6ef5a1c-f82f-11e6-8fb7-db1c38d4ff46.png)

