### PR TITLE
Add "icon crossing out" & template for moderations

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require_relative 'math'
+
 # Change Compass configuration
 compass_config do |config|
   config.add_import_path "bower_components/foundation-sites/scss/"

--- a/math.rb
+++ b/math.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Sass::Script::Functions
+  #
+  # Computes the arctangent in degrees between two vectors. Useful to know how
+  # much rotation the diagonal of a rectangle needs.
+  #
+  def atan2(y, x)
+    y = y.value.to_f
+    x = x.value.to_f
+    result = Math.atan2(y, x) * 180 / Math::PI
+    Sass::Script::Number.new(result)
+  end
+end

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -95,6 +95,9 @@ title: Decidim Admin
               <a href="/process-docs">Documentos</a>
             </li>
             <li>
+              <a href="/process-moderations">Denuncias</a>
+            </li>
+            <li>
               <a href="/process-admin">Administradores</a>
             </li>
           </ul>

--- a/source/partials/_process_sub_nav.html.erb
+++ b/source/partials/_process_sub_nav.html.erb
@@ -61,6 +61,11 @@
     <% end %> >
       <a href="/process-docs">Documentos</a>
     </li>
+    <li <% if current_page.data.activepage == "process-moderations" %>
+     class="is-active"
+    <% end %> >
+      <a href="/process-moderations">Denuncias</a>
+    </li>
     <li <% if current_page.data.activepage == "process-admin" %>
      class="is-active"
     <% end %> >

--- a/source/process-moderations.html.erb
+++ b/source/process-moderations.html.erb
@@ -1,0 +1,54 @@
+---
+title: Decidim Admin
+activesection: processes
+activepage: process-moderations
+---
+
+<%= partial 'partials/template_top' %>
+
+<div class="layout-nav">
+  <%= partial 'partials/process_sub_nav' %>
+</div>
+<div class="layout-content has-process-title">
+  <div class="container">
+    <%= partial 'partials/process_title' %>
+    <div class="card">
+      <div class="card-divider">
+        <h2 class="card-title">Denuncias</h2>
+      </div>
+      <div class="card-section">
+        <div class="table-scroll">
+          <table class="table-list">
+            <thead>
+              <tr>
+                <th>Tipo</th>
+                <th>Contenido</th>
+                <th>Denuncias</th>
+                <th>Número</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Proposal </td>
+                <td>OLA K ASE, la democracia es una mierda. Buuuuuuuh</td>
+                <td>
+                  <span data-tooltip title="En serio? Quitad eso de la web ya!">
+                    does_not_belong
+                  </span>
+                </td>
+                <td>1</td>
+
+                <td class="table-list__actions">
+                  <a href="#"  data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Cancelar denuncia" class="action-icon"><%= icon "action-undo" %></a>
+                  <a href="#" data-tooltip aria-haspopup="true"  data-disable-hover="false" title="Esconder" class="action-icon action-icon--hide"><%= icon "eye" %></a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<%= partial 'partials/template_bottom' %>

--- a/source/stylesheets/modules/_action-icon.scss
+++ b/source/stylesheets/modules/_action-icon.scss
@@ -1,3 +1,10 @@
+$action-icon-height: 24px;
+$action-icon-width: $icon-size;
+
+.action-icon {
+  height: $action-icon-height;
+}
+
 .action-icon:not(:last-child){
   margin-right: 1rem;
 }
@@ -10,4 +17,18 @@
 
 .action-icon.action-icon--remove{
   color: $alert-color;
+}
+
+.action-icon--hide{
+  position: relative;
+
+  &:before{
+    border-left: 1px solid;
+    bottom: 0;
+    content: "";
+    left: 50%;
+    position: absolute;
+    top: 0;
+    transform: rotate(#{atan2($action-icon-width, $action-icon-height)}deg);
+  }
 }

--- a/source/stylesheets/modules/_icons.scss
+++ b/source/stylesheets/modules/_icons.scss
@@ -1,6 +1,8 @@
+$icon-size: 14px;
+
 .icon{
-  width: 14px;
-  height: 14px;
+  width: $icon-size;
+  height: $icon-size;
   fill: currentColor;
 }
 


### PR DESCRIPTION
#### :tophat: Scope of work

Adds a moderations template and some styles adding the ability to include "inverse" (crossed out) icons.

#### :pushpin: Related Issues
- Related to decidim/decidim#1312.

#### :clipboard: Subtasks
_None_

### :camera: URLs
![moderations](https://cloud.githubusercontent.com/assets/2887858/25720831/b1f10900-30e4-11e7-8832-c939852571be.png)

#### :ghost: GIF (optional)
![chaplin](https://cloud.githubusercontent.com/assets/2887858/25720944/1a1987dc-30e5-11e7-87e1-4c5c47c0956b.gif)

